### PR TITLE
Show Manwhore Thumbnails Properly

### DIFF
--- a/src/content/intro/introText.coffee
+++ b/src/content/intro/introText.coffee
@@ -32,7 +32,7 @@ Page.Intro::next = Page.Intro2 = class Intro2 extends Page
     --> `L If it would please you, I would like to make a bargain.`
 
     -- Liana. I know her name without being told.
-    --> Feeble as it is, my magic can still draw facts like that from for mind without thought. Her attitude is pleasant, a mixture of excitement and fear - the first pleasant thing to happen since I awoke bound to the floor by magic.
+    --> Feeble as it is, my magic can still draw facts like that from her mind without thought. Her attitude is pleasant, a mixture of excitement and fear - the first pleasant thing to happen since I awoke bound to the floor by magic.
 
     -- `D Call me mistress.`
     --> `L You are not my mistress. Not yet, at least.`
@@ -75,7 +75,7 @@ Job.IntroFuckLiana::next = Page.IntroFuckLiana = class IntroFuckLiana extends Pa
   text: ->"""|| bg="Liana/Happy.jpg"
     -- I've been... well, if not precisely <i>dead</i>, at least something pretty close for quite some time. And since she's just pledged herself to me...
   || bg="Liana/Grope.jpg"
-    --> I reach a up underneath her shirt, expecting to grope her breasts roughly, and encounter something covering them.
+    --> I reach a hand up underneath her shirt, expecting to grope her breasts roughly, and encounter something covering them.
     --> She grasps my wrist, and I ignore her surprised look, exploring the fabric she has on underneath.
     --> It's springy. Her shirt stretches too, most unnaturally. I frown at her.
 
@@ -127,7 +127,7 @@ Job.IntroFirstSlaves::next = Page.IntroFirstSlaves = class IntroFirstSlaves exte
     --> I laugh. She looks so earnest, worrying about such a thing. And cute, too, with her breasts bobbing and cunt still dripping occasionally. I must be getting soft.
 
   || bg="Liana/Happy.jpg"
-    -- We spend the next several hours going over a bit of local history and geography. "California" seems in just one kingdom in a larger empire, the Yousa. But we're in a small, isolated town which might as well just be begging for conversion into my new stronghold. A couple of foreign wars, but nothing local. Perfect.
+    -- We spend the next several hours going over a bit of local history and geography. "California" seems to be just one kingdom in a larger empire, the Yousa. But we're in a small, isolated town which might as well just be begging for conversion into my new stronghold. A couple of foreign wars, but nothing local. Perfect.
     --> I don't like those things called "cars," though, that she assures me everyone has. The local constables might be able to summon the king's army within a few days. Then they'd burn all my tentacle gardens and lock me up and make me wear a bra in prison. That would be terrible.
 
   || bg="none"
@@ -184,7 +184,7 @@ Job.IntroTakeOver::next = Page.IntroTakeOver = class IntroTakeOver extends Page
     --> `L A bra, mistress.`
 
     --> `D Right. A bra.`
-    -- `D You, slave, she's not to be without a cock inside her for twenty four hours.` I order one of my male slaves to attend to her. `D After that you, bra-girl, return to the front desk. This place is closed for repairs until further notice, no more customers, but keep everything running like normal.`
+    -- `D You, slave, she's not to be without a cock inside her for twenty four hours.` I order one of my male slaves to attend to her. `D After that - you, bra-girl, return to the front desk. This place is closed for repairs until further notice. No more customers, but keep everything running like normal.`
     --> `D You can keep your shirt, since you'll be dealing with the outside world, but while you're behind that counter, no pants or underwear, ever.` Since I haven't actually mind controlled her, just added a hint of obedience and a pound of not-telling-anyone, I back my commands up with a threat. `D Anyone catches you with pants on inside this room, I'll make you work topless too.`
 
     -- Liana, perhaps sensing that I'm liable to keep ranting and raving and piling punishments on the hussy as long as that... thing... remains in my sight, banishes the bra with a spell.
@@ -221,7 +221,7 @@ add class Council extends Page
     -- `L I am happy to serve, mistress. I was hesitant at first - you know how often demons like to talk about taking over the world, and how seldom they actually manage more than getting killed within the first few weeks...`
     --> `D I'm not a demon, as you well know by now.`
 
-    --> `L Oh, of course not mistress. Just explaining why I didn't want to go straight for the throat, as it were. Anyway, the city council meets once a week, and if you lend me some magic, it should be simple enough to wring special concessions out of them...`
+    --> `L Oh, of course not, mistress. Just explaining why I didn't want to go straight for the throat, as it were. Anyway, the city council meets once a week, and if you lend me some magic, it should be simple enough to wring special concessions out of them...`
     -- <em>New location: <b>City Council</b></em>
   """
   apply: ->

--- a/src/content/locations/NorthEnd.coffee
+++ b/src/content/locations/NorthEnd.coffee
@@ -1,6 +1,6 @@
 add class NorthEnd extends Place
   name: 'North End'
-  description: 'I have a "zoning permit" for this area. Time to whatever the fuck I want.'
+  description: 'I have a "zoning permit" for this area. Time to do whatever the fuck I want.'
   image: 'Council/NorthEnd.jpg'
   jobs: new Collection
     Fire: Job.Fire

--- a/src/content/locations/SycamoreStreet.coffee
+++ b/src/content/locations/SycamoreStreet.coffee
@@ -1,6 +1,6 @@
 add class Sycamore extends Place
   name: 'Sycamore Street'
-  description: "Empty businesses, boarded up windows, hookers, broken bottles... it's not much, it's a place to start."
+  description: "Empty businesses, boarded up windows, hookers, broken bottles... it's not much, but it's a place to start."
   image: 'Sycamore/Street.jpg'
   jobs: new Collection
     Fire: Job.Fire
@@ -181,7 +181,7 @@ add class Release extends Page
       """|| bg="Sycamore/Release1.jpg"
         -- Some markers, some rope, a public restroom... I wiped her memory of her time with me and left her there. I'm sure someone will let her out eventually, but for now... public use. Just giving back to the community which has given me so much.""",
       """|| bg="Sycamore/Release2.jpg"
-        -- A bit of magical soundproofing on the box so no one gets suspcious, a letter detailing her circumstances (half-trained slave needs new home), and a random address halfway across the country. Someone's day jsut got brighter.""",
+        -- A bit of magical soundproofing on the box so no one gets suspcious, a letter detailing her circumstances (half-trained slave needs new home), and a random address halfway across the country. Someone's day just got brighter.""",
       """|| bg="Sycamore/Release3.jpg"
         -- Special delivery for the college football team's locker room.""",
       """|| bg="Sycamore/Release4.jpg"
@@ -381,9 +381,9 @@ add class Whore extends Page
         -- Whore. She won't even open her mouth until he's ready to shove a cock in it."""
     ] else if @w1 instanceof Person.Liana then [
       """|| bg="Liana/Whore1.jpg"
-        -- While it's true that I've corrupted Liana to some extent, she somehow retains a core of purity and joy that perhaps I <em>could</em> touch, but really have no desire too. She's a powerful mage, a fiesty temptress, smart and loyal and... I must be coming down with something.
+        -- While it's true that I've corrupted Liana to some extent, she somehow retains a core of purity and joy that perhaps I <em>could</em> touch, but really have no desire to. She's a powerful mage, a feisty temptress, smart and loyal and... I must be coming down with something.
       ||
-        --> Snapping the scrying window closed, I order someone to bring me a cup of pineapple juice, a butt plug and a hole to put it in. I'm supposed to be taking over the world, not feeling jealous of some here human about to fuck her senseless.
+        --> Snapping the scrying window closed, I order someone to bring me a cup of pineapple juice, a butt plug and a hole to put it in. I'm supposed to be taking over the world, not feeling jealous of some mere human about to fuck her senseless.
         -->"""
       """|| bg="Liana/Whore21.jpg"
       || bg="Liana/Whore22.jpg"
@@ -401,7 +401,7 @@ add class Whore extends Page
       """|| bg="Sycamore/WhoreMale2.jpg"
         -- """
       """|| bg="Sycamore/WhoreMale3.jpg"
-        -- Seriously, what sort of gut just carries a leash and colar in his pocket, in case he happens to stumble across some casual sex?
+        -- Seriously, what sort of gut just carries a leash and collar in his pocket, in case he happens to stumble across some casual sex?
         --> The awesome kind, clearly."""
       """|| bg="Sycamore/WhoreMale4.jpg"
         -- Busy day at the office, but still want to fuck? Call Dark Lady's Escorts now. We deliver."""

--- a/src/content/people/TrainingChamber.coffee
+++ b/src/content/people/TrainingChamber.coffee
@@ -98,7 +98,7 @@ add class ManWhore extends Person
   description: ->"""He's got a cock, an asshole and a mouth, and he's not afraid to have any of them used. He'd rather enjoy it, in fact."""
   image: sticky
   @images: [
-    'TrainingChamber/SS31.jpg'
-    'TrainingChamber/SS41.jpg'
-    'TrainingChamber/SS51.jpg'
+    'TrainingChamber/MH1.jpg'
+    'TrainingChamber/MH2.jpg'
+    'TrainingChamber/MH3.jpg'
   ]

--- a/src/content/rooms/medium/library.coffee
+++ b/src/content/rooms/medium/library.coffee
@@ -59,7 +59,7 @@ Job.Library::next = add class LibraryDaily extends Page
       l.push """|| bg="Library/Nude1.jpg"
         -- It's exhausting, keeping the shelves straight when most visitors would rather fuck you than complete their assigned research."""
       l.push """|| bg="Library/Nude2.jpg"
-        -- "Look, I can see you're a distracted. Shall I help you relax before a bit before you get started?" """
+        -- "Look, I can see you're distracted. Shall I help you relax before a bit before you get started?" """
 
     return """|| class="jobStart" auto="1800"
       <h4>Library</h4>

--- a/src/content/rooms/medium/library.coffee
+++ b/src/content/rooms/medium/library.coffee
@@ -43,7 +43,7 @@ Job.Library::next = add class LibraryDaily extends Page
     if Math.random() < 0.75  or g.events.LibraryDaily?[0] is g.day then return false
     l = [
       """|| bg="Library/Belly.jpg"
-        -- "Can I help you find anything, #{if @worker.gender is 'f' then "ma'am" else 'sir'}? M-my shirt? Yes, I-I suppose, if you wish..." """,
+        -- "Can I help you find anything, #{sir}? M-my shirt? Yes, I-I suppose, if you wish..." """,
       """|| bg="Library/Empty.jpg"
         -- Books, books, books. Heart and soul of the amazing power of "California", Liana insists, but I'm not really a fan."""
     ]

--- a/src/engine/classes/person.coffee
+++ b/src/engine/classes/person.coffee
@@ -12,6 +12,7 @@ window.His = (p = lastP)-> lastP = p; if p.gender is 'f' then 'Her' else 'His'
 window.boy = (p = lastP)-> lastP = p; if p.gender is 'f' then 'girl' else 'boy'
 window.man = (p = lastP)-> lastP = p; if p.gender is 'f' then 'woman' else 'man'
 window.men = (p = lastP)-> lastP = p; if p.gender is 'f' then 'women' else 'men'
+window.sir = (p = lastP)-> lastP = p; if p.gender is 'f' then "ma'am" else 'sir'
 he.toString = he
 He.toString = He
 him.toString = him

--- a/src/engine/classes/person.coffee
+++ b/src/engine/classes/person.coffee
@@ -20,6 +20,7 @@ His.toString = His
 boy.toString = boy
 man.toString = man
 men.toString = men
+sir.toString = sir
 
 statSchema = {type: 'number', gte: 0, lte: 100}
 


### PR DESCRIPTION
Fixes manwhores accidentally using the sex slave thumbnails
Makes them use their own instead.

Contains spelling fixes.
